### PR TITLE
Small improvements to the install front page

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -16258,9 +16258,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -16621,9 +16621,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.77.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
+      "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -28857,9 +28857,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "requires": {
             "minimist": "^1.2.0"
           }
@@ -29120,9 +29120,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.77.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.77.0.tgz",
+      "integrity": "sha512-sbGNjBr5Ya5ss91yzjeJTLKyfiwo5C628AFjEa6WSXcZa4E+F57om3Cc8xLb1Jh0b243AWuSYRf3dn7HVeFQ9Q==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -28,7 +28,6 @@ export default function App() {
     })(),
   );
 
-
   const [nodeMonitor, setNodeMonitor] = React.useState<NodeMonitor | undefined>(
     undefined,
   );
@@ -61,7 +60,7 @@ export default function App() {
             },
             status: 'Down',
             wallet_infos: {
-              Address: "",
+              Address: '',
               Thread: 0,
               Candidate_rolls: 0,
               Final_rolls: 0,
@@ -69,7 +68,7 @@ export default function App() {
               Final_balance: '0',
               Candidate_balance: '0',
             },
-            node_infos: {} as NodeStatus
+            node_infos: {} as NodeStatus,
           });
           console.error(error);
         });
@@ -103,8 +102,8 @@ export default function App() {
     }, 2000);
 
     return () => {
-      clearInterval(fetchNodeInt)
-      clearInterval(monitorInt)
+      clearInterval(fetchNodeInt);
+      clearInterval(monitorInt);
     };
   }, [selectedNode, nodeMonitor]);
 
@@ -138,7 +137,7 @@ export default function App() {
             transform: 'translate(-50%, -50%)',
           }}
         />
-      ) : (!isUpdating && selectedNode) ? (
+      ) : !isUpdating && selectedNode ? (
         <Manager
           selectedNode={selectedNode}
           nodeMonitor={nodeMonitor}

--- a/front/src/pages/Install.tsx
+++ b/front/src/pages/Install.tsx
@@ -163,7 +163,7 @@ const Install: React.FC<Props> = (props: Props) => {
         onChange={(e) => setHost(e.target.value)}
         defaultValue={props.selectedNode?.Host}
       />
-      <Tooltip title="A wallet is created for staking. This password is used to encrypt the wallet.">
+      <Tooltip title="A wallet will be created for staking purposes. Define password of your choice.">
         <TextField
           required
           sx={{ mt: '8px' }}
@@ -174,7 +174,7 @@ const Install: React.FC<Props> = (props: Props) => {
           defaultValue={props.selectedNode?.WalletPassword}
         />
       </Tooltip>
-      <Tooltip title="This token is used to log into a Discord account to perfom some actions such as asking coins to the faucet.">
+      <Tooltip title="This token is used to log into your Discord account. Add it if you want to participate to Massa Testnet reward program.">
         <TextField
           sx={{ mt: '8px' }}
           label="Discord token"

--- a/front/src/pages/Install.tsx
+++ b/front/src/pages/Install.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {
   Button,
   TextField,
@@ -11,8 +12,11 @@ import {
   RadioGroup,
   FormControlLabel,
   Radio,
+  Tooltip,
 } from '@mui/material';
+
 import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+
 import { localApiPost } from '../request';
 import Node from '../types/Node';
 
@@ -29,18 +33,29 @@ const Install: React.FC<Props> = (props: Props) => {
   const [isLoading, setIsLoading] = React.useState<boolean>(false);
   const [name, setName] = React.useState(props.selectedNode?.Id ?? '');
   const [host, setHost] = React.useState(props.selectedNode?.Host ?? '');
-  const [password, setPassword] = React.useState(props.selectedNode?.WalletPassword ?? '');
-  const [sshPassword, setSshPassword] = React.useState(props.selectedNode?.SshPassword ?? '');
-  const [username, setUser] = React.useState(props.selectedNode?.Username ?? '');
-  const [discordId, setDiscord] = React.useState(props.selectedNode?.DiscordId ?? '');
+  const [password, setPassword] = React.useState(
+    props.selectedNode?.WalletPassword ?? '',
+  );
+  const [sshPassword, setSshPassword] = React.useState(
+    props.selectedNode?.SshPassword ?? '',
+  );
+  const [username, setUser] = React.useState(
+    props.selectedNode?.Username ?? '',
+  );
+  const [discordId, setDiscord] = React.useState(
+    props.selectedNode?.DiscordId ?? '',
+  );
   const [selectedFile, setSelectedFile] = React.useState<File | null>(null);
-  const [sshType, setSshType] = React.useState((props.selectedNode && props.selectedNode?.SshPassword != '') ? 'password' : 'key');
+  const [sshType, setSshType] = React.useState(
+    props.selectedNode && props.selectedNode?.SshPassword != ''
+      ? 'password'
+      : 'key',
+  );
 
   const installNode = () => {
-
     setIsLoading(true);
 
-    const sshPwd = sshType === "key" ? "" : sshPassword
+    const sshPwd = sshType === 'key' ? '' : sshPassword;
     const formData = new FormData();
     formData.append('id', name);
     formData.append('host', host);
@@ -59,8 +74,8 @@ const Install: React.FC<Props> = (props: Props) => {
       WalletPassword: password,
       SshPassword: sshPwd,
       DiscordId: discordId,
-      Status: "Installing",
-    }
+      Status: 'Installing',
+    };
     props.SetNode(newNode);
 
     localApiPost(
@@ -84,14 +99,14 @@ const Install: React.FC<Props> = (props: Props) => {
           WalletPassword: password,
           SshPassword: sshPassword,
           DiscordId: discordId,
-          Status: "Installing",
-        }
+          Status: 'Installing',
+        };
         props.SetNode(newNode);
       })
       .catch((error) => {
         console.error(error);
         setIsLoading(false);
-        props.fetchNodes()
+        props.fetchNodes();
       });
   };
 
@@ -119,9 +134,22 @@ const Install: React.FC<Props> = (props: Props) => {
         justifyContent: 'center',
       }}
     >
+      <Typography variant="h4">
+        Install and manage your node in 1-click.
+      </Typography>
+      <Typography variant="h5" sx={{ mb: '16px' }}>
+        You simply need a{' '}
+        <Link
+          underline="hover"
+          href="https://github.com/massalabs/thyra-node-manager-plugin/wiki/Get-your-VPS"
+        >
+          <b>server</b>
+        </Link>{' '}
+        and you can start.
+      </Typography>
       <TextField
         required
-        sx={{ marginTop: '8px' }}
+        sx={{ mt: '8px' }}
         label="Node Name"
         id="name"
         onChange={(e) => setName(e.target.value)}
@@ -129,37 +157,43 @@ const Install: React.FC<Props> = (props: Props) => {
       />
       <TextField
         required
-        sx={{ marginTop: '8px' }}
+        sx={{ mt: '8px' }}
         label="Host IP"
         id="host"
         onChange={(e) => setHost(e.target.value)}
         defaultValue={props.selectedNode?.Host}
       />
-      <TextField
-        required
-        sx={{ marginTop: '8px' }}
-        label="Wallet password"
-        id="password"
-        type="password"
-        onChange={(e) => setPassword(e.target.value)}
-        defaultValue={props.selectedNode?.WalletPassword}
-      />
-      <TextField
-        sx={{ marginTop: '8px' }}
-        label="Discord token"
-        id="discordId"
-        onChange={(e) => setDiscord(e.target.value)}
-        defaultValue={props.selectedNode?.DiscordId}
-      />
-      <TextField
-        required
-        sx={{ marginTop: '8px' }}
-        label="SSH user"
-        id="username"
-        onChange={(e) => setUser(e.target.value)}
-        defaultValue={props.selectedNode?.Username}
-      />
-      <FormControl component="fieldset" sx={{ marginTop: '8px' }}>
+      <Tooltip title="A wallet is created for staking. This password is used to encrypt the wallet.">
+        <TextField
+          required
+          sx={{ mt: '8px' }}
+          label="Wallet password"
+          id="password"
+          type="password"
+          onChange={(e) => setPassword(e.target.value)}
+          defaultValue={props.selectedNode?.WalletPassword}
+        />
+      </Tooltip>
+      <Tooltip title="This token is used to send you a notification on Discord when your node has an issue.">
+        <TextField
+          sx={{ mt: '8px' }}
+          label="Discord token"
+          id="discordId"
+          onChange={(e) => setDiscord(e.target.value)}
+          defaultValue={props.selectedNode?.DiscordId}
+        />
+      </Tooltip>
+      <Tooltip title="The username used to connect to your server.">
+        <TextField
+          required
+          sx={{ mt: '8px' }}
+          label="SSH user"
+          id="username"
+          onChange={(e) => setUser(e.target.value)}
+          defaultValue={props.selectedNode?.Username}
+        />
+      </Tooltip>
+      <FormControl component="fieldset" sx={{ mt: '8px' }}>
         <FormLabel component="legend">SSH Authentication</FormLabel>
         <RadioGroup
           row
@@ -168,14 +202,22 @@ const Install: React.FC<Props> = (props: Props) => {
           value={sshType}
           onChange={(e) => setSshType(e.target.value)}
         >
-          <FormControlLabel value="key" control={<Radio />} label="Ssh key file" />
-          <FormControlLabel value="password" control={<Radio />} label="Password" />
+          <FormControlLabel
+            value="key"
+            control={<Radio />}
+            label="Ssh key file"
+          />
+          <FormControlLabel
+            value="password"
+            control={<Radio />}
+            label="Password"
+          />
         </RadioGroup>
       </FormControl>
       {sshType === 'password' ? (
         <TextField
           required
-          sx={{ marginTop: '8px' }}
+          sx={{ mt: '4px' }}
           label="SSH password"
           id="password"
           type="password"
@@ -197,14 +239,14 @@ const Install: React.FC<Props> = (props: Props) => {
               backgroundColor: '#1976d2',
               borderColor: '#1976d2',
             },
-            marginTop: '16px',
           }}
           startIcon={<CloudUploadIcon />}
         >
-          {selectedFile ? selectedFile.name :
-            (props.isUpdating && props.selectedNode?.SshPassword == '') ?
-              `${props.selectedNode?.Id}-key.ssh` :
-              'Select SSH private key file'}
+          {selectedFile
+            ? selectedFile.name
+            : props.isUpdating && props.selectedNode?.SshPassword == ''
+            ? `${props.selectedNode?.Id}-key.ssh`
+            : 'Select SSH private key file'}
           <input
             type="file"
             style={{ display: 'none' }}
@@ -218,38 +260,26 @@ const Install: React.FC<Props> = (props: Props) => {
         color="primary"
         onClick={installNode}
         sx={{
-          borderRadius: 8,
-          width: { xs: '100%', sm: '100%', md: '450px', lg: '550px' },
-          height: '96px',
-          marginTop: '16px',
+          borderRadius: 5,
+          width: { xs: '100%', sm: '50%', md: '350px', lg: '450px' },
+          height: '64px',
+          mt: '20px',
         }}
       >
         {isLoading ? (
           <CircularProgress size={24} />
         ) : (
-          <Typography variant="h6">{props.isUpdating ? "Update node" : "Setup node"}</Typography>
+          <Typography variant="h6">
+            {props.isUpdating ? 'Update node' : 'Setup node'}
+          </Typography>
         )}
       </Button>
-
       <Typography variant="overline">
         By clicking the button above, you will install a node on your server.
       </Typography>
 
-      <Typography variant="h5" sx={{ mt: 4 }}>
-        Install and manage your node in 1-click,
-      </Typography>
-      <Typography variant="h5">
-        You simply need a VPS{' '}
-        <Link
-          underline="hover"
-          href="https://github.com/massalabs/thyra-node-manager-plugin/wiki/Get-your-VPS"
-        >
-          <b>click here</b>
-        </Link>{' '}
-        and you can start
-      </Typography>
       <Typography variant="h4" sx={{ mt: 4 }}>
-        Don't wait, become an actor of the decentralisation <b>now! </b>
+        Don't wait, become an actor of the decentralisation <b>now</b> !
       </Typography>
     </Container>
   );

--- a/front/src/pages/Install.tsx
+++ b/front/src/pages/Install.tsx
@@ -150,7 +150,7 @@ const Install: React.FC<Props> = (props: Props) => {
       <TextField
         required
         sx={{ mt: '8px' }}
-        label="Node Name"
+        label="Node nickname"
         id="name"
         onChange={(e) => setName(e.target.value)}
         defaultValue={props.selectedNode?.Id}
@@ -158,7 +158,7 @@ const Install: React.FC<Props> = (props: Props) => {
       <TextField
         required
         sx={{ mt: '8px' }}
-        label="Host IP"
+        label="Server IP"
         id="host"
         onChange={(e) => setHost(e.target.value)}
         defaultValue={props.selectedNode?.Host}
@@ -183,16 +183,14 @@ const Install: React.FC<Props> = (props: Props) => {
           defaultValue={props.selectedNode?.DiscordId}
         />
       </Tooltip>
-      <Tooltip title="The username used to connect to your server.">
-        <TextField
-          required
-          sx={{ mt: '8px' }}
-          label="SSH user"
-          id="username"
-          onChange={(e) => setUser(e.target.value)}
-          defaultValue={props.selectedNode?.Username}
-        />
-      </Tooltip>
+      <TextField
+        required
+        sx={{ mt: '8px' }}
+        label="SSH user"
+        id="username"
+        onChange={(e) => setUser(e.target.value)}
+        defaultValue={props.selectedNode?.Username}
+      />
       <FormControl component="fieldset" sx={{ mt: '8px' }}>
         <FormLabel component="legend">SSH Authentication</FormLabel>
         <RadioGroup

--- a/front/src/pages/Install.tsx
+++ b/front/src/pages/Install.tsx
@@ -174,7 +174,7 @@ const Install: React.FC<Props> = (props: Props) => {
           defaultValue={props.selectedNode?.WalletPassword}
         />
       </Tooltip>
-      <Tooltip title="This token is used to send you a notification on Discord when your node has an issue.">
+      <Tooltip title="This token is used to log into a Discord account to perfom some actions such as asking coins to the faucet.">
         <TextField
           sx={{ mt: '8px' }}
           label="Discord token"

--- a/front/src/request.ts
+++ b/front/src/request.ts
@@ -52,7 +52,7 @@ export const localApiGet = async (
   path: string,
   options?: AxiosRequestConfig,
   // Change to personal port
-) => apiGet(`${localPrefixUrl}${path}`,options);
+) => apiGet(`${localPrefixUrl}${path}`, options);
 
 export const apiGet = async (url: string, options?: AxiosRequestConfig) => {
   return axios


### PR DESCRIPTION

We had a quick discussion with @SlnPons to improve the install page. 
We decided to:
- Change `VPS` to `server` since we target any kind of server
- Remove the "Click here" and make the `server` clickable
- Move "Install and Manage..." and "You simply need a server..." to the top
- Add some tooltips 
- Reduce the size of the "setup node" button

Previous:
![image](https://user-images.githubusercontent.com/44696378/229831937-e1e9277f-8959-4745-ad84-4a1c97d7ada3.png)


New:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/44696378/229831828-8098a615-57d2-4e7e-a0d6-8c8b71a24000.png">
